### PR TITLE
Fix issues with category logos

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,7 +9,6 @@ span.category-badge-icon {
 
 .categories .category h3,
 .badge-wrapper .badge-category {
-  display: inline-flex;
   .d-icon {
     margin-right: 5px;
     &:not(.d-icon-lock) {
@@ -23,10 +22,15 @@ span.category-badge-icon {
   .d-icon:not(.d-icon-lock) {
     color: inherit;
   }
-  div {
-    display: inline;
-  }
   .category-icon-widget {
     vertical-align: baseline;
   }
+}
+
+.categories-list .category-box-heading h3 div {
+  display: inline;
+}
+
+.category-list .category h3 > div {
+  float: left;
 }


### PR DESCRIPTION
I had overlooked category logos. This should fix up the layout:

<img width="562" alt="Screen Shot 2019-08-12 at 1 45 06 PM" src="https://user-images.githubusercontent.com/22733864/62897124-6e08c500-bd07-11e9-8725-8e9c81f72b2a.png">
