### PR TITLE
Allow slug partial-match option

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,4 +1,5 @@
 <script type="text/discourse-plugin" version="0.8.26">
+// modified RCO Jan 2019 to allow partial match on category-slug
   let categoryThemeList = settings.category_icon_list.split('|');
   let lockIcon = settings.category_lock_icon || 'lock';
 
@@ -15,14 +16,19 @@
   }
 
   function getIconItem(categorySlug) {
-    let categoryThemeItem = categoryThemeList.find((str) => str.indexOf(categorySlug) > -1);
+  	// return nothing if categorySlug not specified
+  	if (!categorySlug) return;
+    let categoryThemeItem = categoryThemeList.find((str) => 
+    	str.indexOf(",") > -1 ? categorySlug.indexOf(str.substr(0,str.indexOf(","))) > -1 : '');
     if (categoryThemeItem) {
-      let iconItem = categoryThemeItem.split(',');
-      // Ensure exact match
-      if(iconItem[0] === categorySlug) {
-        return iconItem;
-      }
-    }
+    	let iconItem = categoryThemeItem.split(',');
+    	// Test partial/exact match
+        if(iconItem[3]=='partial') {
+            return iconItem;
+        } else if(iconItem[0] === categorySlug) {
+            return iconItem;
+        }
+	}
   }
 
   function categoryIconsRenderer(category, opts) {

--- a/settings.yml
+++ b/settings.yml
@@ -1,7 +1,7 @@
 category_icon_list: 
-  default: 'help,question-circle,#CC0000|'
+  default: 'help,question-circle,#CC0000,partial|'
   type: 'list'
-  description: 'Enter comma-delimited configuration for categories, in the format "category-slug,icon,color".'
+  description: 'Enter comma-delimited configuration for categories, in the format "slug,icon,colour,match". If  match is "partial" then the slug need only partially match the category-slug, otherwise an exact match is required'
 svg_icons: 
   default: 'question-circle'
   type: 'list'


### PR DESCRIPTION
Hi this PR allows option to partially match on the category-slug so, for example, all categories contain "help" get the same icon. Default is the existing behaviour - require exact match